### PR TITLE
Fix image resize aspect ratio bug

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2889,7 +2889,7 @@ def _resize(width: int, height: int) -> tuple[int, int]:
             width = (width * 768) // height
             height = 768
         else:
-            height = (width * 768) // height
+            height = (height * 768) // width
             width = 768
     return width, height
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_resize.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_resize.py
@@ -1,0 +1,6 @@
+from langchain_openai.chat_models.base import _resize
+
+
+def test_resize_smaller_side_scaled_correctly() -> None:
+    width, height = _resize(1000, 2000)
+    assert width == 768 and height == 1536


### PR DESCRIPTION
## Summary
- correct aspect ratio calculation in `_resize`
- add unit test for `_resize` behavior

## Testing
- `uv run pytest libs/partners/openai/tests/unit_tests/chat_models/test_resize.py` *(fails: ModuleNotFoundError: No module named 'langchain_tests')*

------
https://chatgpt.com/codex/tasks/task_e_683fc696f05883218fb6018e8474fec2