### PR TITLE
openai: fix resize aspect ratio bug

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2875,22 +2875,26 @@ def _is_b64(s: str) -> bool:
 
 
 def _resize(width: int, height: int) -> tuple[int, int]:
-    # larger side must be <= 2048
+    """Resize an image while preserving the aspect ratio."""
+
+    # scale such that the larger side does not exceed 2048
     if width > 2048 or height > 2048:
         if width > height:
-            height = (height * 2048) // width
-            width = 2048
+            ratio = 2048 / width
         else:
-            width = (width * 2048) // height
-            height = 2048
-    # smaller side must be <= 768
+            ratio = 2048 / height
+        width = max(1, int(round(width * ratio)))
+        height = max(1, int(round(height * ratio)))
+
+    # scale such that the smaller side does not exceed 768
     if width > 768 and height > 768:
-        if width > height:
-            width = (width * 768) // height
-            height = 768
+        if width < height:
+            ratio = 768 / width
         else:
-            height = (height * 768) // width
-            width = 768
+            ratio = 768 / height
+        width = max(1, int(round(width * ratio)))
+        height = max(1, int(round(height * ratio)))
+
     return width, height
 
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_resize.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_resize.py
@@ -4,3 +4,8 @@ from langchain_openai.chat_models.base import _resize
 def test_resize_smaller_side_scaled_correctly() -> None:
     width, height = _resize(1000, 2000)
     assert width == 768 and height == 1536
+
+
+def test_resize_aspect_ratio_preserved() -> None:
+    width, height = _resize(3000, 1000)
+    assert width == 2048 and height == 683


### PR DESCRIPTION
## Summary
- preserve aspect ratio when resizing images
- add regression tests for `_resize`

This fixes the scaling error in `_resize` while introducing no new dependencies or related issues.

------
https://chatgpt.com/codex/tasks/task_e_683fdc46f8bc8321b3e27f7ca209f593